### PR TITLE
Add specific school presets for the DE

### DIFF
--- a/data/fields/isced/level-US,DE.json
+++ b/data/fields/isced/level-US,DE.json
@@ -1,7 +1,8 @@
 {
     "locationSet": {
         "include": [
-            "us"
+            "us",
+            "de"
         ]
     },
     "key": "isced:level",

--- a/data/presets/amenity/school.json
+++ b/data/presets/amenity/school.json
@@ -2,7 +2,7 @@
     "icon": "temaki-school",
     "fields": [
         "name",
-        "isced/level-US",
+        "isced/level-US,DE",
         "operator",
         "operator/type",
         "address",

--- a/data/presets/amenity/school/1-US,DE.json
+++ b/data/presets/amenity/school/1-US,DE.json
@@ -2,12 +2,12 @@
     "icon": "temaki-school",
     "locationSet": {
         "include": [
-            "us"
+            "us",
+            "de"
         ]
     },
     "terms": [
-        "junior high school",
-        "intermediate school"
+        "primary school"
     ],
     "geometry": [
         "area",
@@ -15,10 +15,10 @@
     ],
     "tags": {
         "amenity": "school",
-        "isced:level": "2"
+        "isced:level": "1"
     },
     "reference": {
         "key": "isced:level"
     },
-    "name": "Middle School Grounds"
+    "name": "Elementary School Grounds"
 }

--- a/data/presets/amenity/school/2-US,DE.json
+++ b/data/presets/amenity/school/2-US,DE.json
@@ -1,0 +1,25 @@
+{
+    "icon": "temaki-school",
+    "locationSet": {
+        "include": [
+            "us",
+            "de"
+        ]
+    },
+    "terms": [
+        "junior high school",
+        "intermediate school"
+    ],
+    "geometry": [
+        "area",
+        "point"
+    ],
+    "tags": {
+        "amenity": "school",
+        "isced:level": "2"
+    },
+    "reference": {
+        "key": "isced:level"
+    },
+    "name": "Middle School Grounds"
+}

--- a/data/presets/amenity/school/3-DE.json
+++ b/data/presets/amenity/school/3-DE.json
@@ -2,11 +2,13 @@
     "icon": "temaki-school",
     "locationSet": {
         "include": [
-            "us"
+            "de"
         ]
     },
     "terms": [
-        "primary school"
+        "secondary school",
+        "grade 12",
+        "grade 13"
     ],
     "geometry": [
         "area",
@@ -14,10 +16,10 @@
     ],
     "tags": {
         "amenity": "school",
-        "isced:level": "1"
+        "isced:level": "2;3"
     },
     "reference": {
         "key": "isced:level"
     },
-    "name": "Elementary School Grounds"
+    "name": "Secondary School Grounds (Grade 5-12/13)"
 }

--- a/interim/source_strings.yaml
+++ b/interim/source_strings.yaml
@@ -2805,8 +2805,8 @@ en:
         # interval=*
         label: Interval
         terms: '[translate with synonyms or related terms for ''Interval'', separated by commas]'
-      isced/level-US:
-        # isced:level=* | Local preset for countries "US"
+      isced/level-US,DE:
+        # isced:level=* | Local preset for countries "US", "DE"
         label: Type
         options:
           # isced:level=1
@@ -7100,16 +7100,21 @@ en:
         name: School Grounds
         # 'terms: academy,elementary school,middle school,high school'
         terms: <translate with synonyms or related terms for 'School Grounds', separated by commas>
-      amenity/school/1-US:
-        # amenity=school + isced:level=1 | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key). | Local preset for countries "US"
+      amenity/school/1-US,DE:
+        # amenity=school + isced:level=1 | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key). | Local preset for countries "US", "DE"
         name: Elementary School Grounds
         # 'terms: primary school'
         terms: <translate with synonyms or related terms for 'Elementary School Grounds', separated by commas>
-      amenity/school/2-US:
-        # amenity=school + isced:level=2 | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key). | Local preset for countries "US"
+      amenity/school/2-US,DE:
+        # amenity=school + isced:level=2 | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key). | Local preset for countries "US", "DE"
         name: Middle School Grounds
         # 'terms: junior high school,intermediate school'
         terms: <translate with synonyms or related terms for 'Middle School Grounds', separated by commas>
+      amenity/school/3-DE:
+        # amenity=school + isced:level=2;3 | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key). | Local preset for countries "DE"
+        name: Secondary School Grounds (Grade 5-12/13)
+        # 'terms: secondary school,grade 12,grade 13'
+        terms: <translate with synonyms or related terms for 'Secondary School Grounds (Grade 5-12/13)', separated by commas>
       amenity/school/3-US:
         # amenity=school + isced:level=3 | Translate the primary name. Optionally, add equivalent synonyms on newlines in order of preference (press the Return key). | Local preset for countries "US"
         name: High School Grounds


### PR DESCRIPTION
This is based on https://github.com/openstreetmap/id-tagging-schema/pull/1021. Thanks for the inspiration to solve this like you did, @arch0345.

I reused the school and isced level presets and fields from #1021 whenever possible. It will be important to add the correct translations during the translation process
- `school/1-US,DE.json` => "Grundschule"
- `school/2-US,DE.json` => "Sekundarschule ohne Oberstufe"
  - terms: "Sekundarstufe I", "Mittelstufe"
  - More terms via https://wiki.openstreetmap.org/wiki/DE:Key:isced:level#Werte_f.C3.BCr_D-A-CH
  - Local terms for "Bundesländer" at https://de.wikipedia.org/wiki/Schulsystem_in_Deutschland#Sekundarstufe_I, eg. "Stadtteilschule"
- `school/2-DE.json` => "Sekundarschule mit Oberstufe"
  - terms: "Sekundarstufe II", "Oberstufe"
  - More terms via https://wiki.openstreetmap.org/wiki/DE:Key:isced:level#Werte_f.C3.BCr_D-A-CH

The ISCED level fields work nicely with the multiCombo by automatically selecting the right preset based on the field combinations.

Right now this PR is based on https://github.com/arch0345/id-tagging-schema/tree/us-schools to make comparing changes easier with #1021. I suggest to merge #1021 first and then change the base in this PR to [`openstreetmap:main`](https://github.com/openstreetmap/id-tagging-schema/tree/main).

---

This is a fresh take on and supersedes https://github.com/openstreetmap/id-tagging-schema/pull/331